### PR TITLE
Fix layout breakage caused by skeevy custom page file on the google search page

### DIFF
--- a/wwwroot/phpbb/styles/art_deluxe/template/googlesearch_body.html
+++ b/wwwroot/phpbb/styles/art_deluxe/template/googlesearch_body.html
@@ -3,7 +3,7 @@
 <h2 class="solo"> Search forum using Google</h2>
 
 <div class="panel">
-	<div class="inner"><span class="corners-top"><span></span></span>
+	<div class="inner">
 	
 		<script>
 		  (function() {
@@ -22,8 +22,5 @@
 	</div>
 </div>
 
-   <span class="corners-bottom"><span></span></span></div>
-</div>
 
-<!-- INCLUDE jumpbox.html -->
 <!-- INCLUDE overall_footer.html -->


### PR DESCRIPTION
These lines are leftovers from before I converted almost the entire theme to css drawn graphics.
