### PR TITLE
Make post links and attachments stand out more

### DIFF
--- a/wwwroot/phpbb/styles/spring/theme/overrides.css
+++ b/wwwroot/phpbb/styles/spring/theme/overrides.css
@@ -103,6 +103,7 @@ fieldset.fields1 dd {
 
 /* Sexy Additions */
 
+/* Images in posts */
 .postbody img.postimage {
 	margin-top: 5px;
 	margin-bottom: 5px;
@@ -111,6 +112,42 @@ fieldset.fields1 dd {
 	background-color: rgba(255,255,255,1);
 	border: 1px dashed #999;
 	box-shadow: 2px 2px 5px rgba(0,0,0,0.3);
+}
+
+/* Links in posts */
+a.postlink:after {
+    font-family: FontAwesome;
+    content: " \f08e";
+
+}
+
+a.postlink {
+    display: inline-block;
+	word-break: break-all;
+    max-width: 96%;
+    margin-top: 5px;
+    margin-bottom: 5px;
+    margin-left: 5px;
+    margin-right: 5px;
+    padding: 5px;
+    font-weight: bold;
+    background-color: rgba(255,255,255,1);
+    border: 1px dashed #999;
+    box-shadow: 2px 2px 5px rgba(0,0,0,0.3);
+}
+
+/* Attachments */
+.imageset.icon_topic_attach:before {
+    font-family: FontAwesome;
+    content: " \f0c6";
+    position: absolute;
+    margin-top: -13px;
+
+}
+
+.imageset.icon_topic_attach {
+    background-image: none;
+    margin-right: 13px;
 }
 
 .postbody .inline-attachment {


### PR DESCRIPTION
This could possibly be a bit controversial. I don't think people will dislike it, but it does change the way that links are done in posts, and imo, it makes the links stand out way better this way. Here are some examples (I have tried to include ones where it might not be as attractive, so that you can see the entire gamut):

http://i.imgur.com/qJ7InBn.png
http://i.imgur.com/I8Dl12K.png
http://i.imgur.com/ZPnIshT.png
http://i.imgur.com/6uMa7hF.png
http://i.imgur.com/AJF3ijA.png
http://i.imgur.com/z567TSx.png

Before this change, Flozi's post looks like this:
http://i.imgur.com/D2laoLV.png

After this change, it looks like this, which is, imo, much more readable:
http://i.imgur.com/Z5biKb6.png

And this is what it looks like when you hover over the links:
http://i.imgur.com/0zzc1EG.png

It also makes images that are links, visible that they link to something:
http://i.imgur.com/nb0KYs6.png

:hover
http://i.imgur.com/aDrQKcY.png