### PR TITLE
Dump the spring banner when not on the main site, replace with navbar

### DIFF
--- a/wwwroot/mediawiki/skins/SpringNew.php
+++ b/wwwroot/mediawiki/skins/SpringNew.php
@@ -22,7 +22,8 @@ class SkinSpringNew extends SkinLegacy {
 	function setupSkinUserCss(OutputPage $out) {
 		parent::setupSkinUserCss($out);
 		$meta = file_get_contents('../templates/meta.html');
-		$meta = str_replace('{META}', "<link href='/skins/mediawiki/spring.css' rel='stylesheet' type='text/css' />", $meta);
+		$meta = str_replace('{META}', "<link href='/skins/mediawiki/spring.css' rel='stylesheet' type='text/css' />
+										<link href='/phpbb/styles/spring/theme/header-navbar.css' rel='stylesheet' type='text/css' />", $meta); /* Import the navbar css too */
 		$out->addHeadItem("spring_meta", $meta);
 	}
 };
@@ -40,7 +41,7 @@ class SpringNewTemplate extends LegacyTemplate {
 		$qb = $this->getSkin()->qbSetting();
 		$mainPageObj = Title::newMainPage();
 
-		$s .= file_get_contents('../templates/header.html');
+		$s .= file_get_contents('../templates/header-offsite.html');
 		$title = htmlspecialchars($wgOut->getPageTitle());
 
 		$s = str_replace('{PAGE_TITLE}', $title, $s);

--- a/wwwroot/phpbb/styles/spring/template/spring_header.html
+++ b/wwwroot/phpbb/styles/spring/template/spring_header.html
@@ -1,1 +1,1 @@
-../../../../templates/header.html
+../../../../templates/header-offsite.html

--- a/wwwroot/phpbb/styles/spring/theme/header-navbar.css
+++ b/wwwroot/phpbb/styles/spring/theme/header-navbar.css
@@ -4,7 +4,7 @@
 
 .header-navbar-background {
 	display: block;
-	position: fixed;
+	position: absolute;
 	top: 0;
 	left: 0;
 	width: 100%;

--- a/wwwroot/phpbb/styles/spring/theme/header-navbar.css
+++ b/wwwroot/phpbb/styles/spring/theme/header-navbar.css
@@ -1,0 +1,74 @@
+#wrapper {
+	margin-top: 60px;
+}
+
+.header-navbar-background {
+	display: block;
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	background-color: #222;
+	height: 40px;
+	border-bottom: 2px solid #555;
+	z-index: 999999;
+}
+
+.header-navbar-container {
+	display: block;
+	position: relative;
+	margin-left: auto;
+	margin-right: auto;
+	width: 100%;
+	max-width: 1000px;
+}
+
+.header-navbar-container img.spring-logo {
+	float: left;
+	max-width: 175px;
+	margin-left: 15px;
+	margin-top: 4px;
+}
+
+.header-navbar-menu {
+	margin-top: 14px;
+	margin-right: 15px;
+	float: right;
+}
+
+.header-navbar-menu ul {
+	display: inline-block;
+	list-style: none;
+}
+
+.header-navbar-menu ul li {
+	float: left;
+	margin-left: 5px;
+	margin-right: 5px;
+}
+
+.header-navbar-menu ul li a {
+	color: #fff;
+}
+
+.header-navbar-menu ul li a:hover {
+	color: #fff;
+	text-shadow: 0px 0px 10px #fff;
+	text-decoration: none;
+}
+
+@media screen and (max-width: 750px) {
+	#wrapper {
+		margin-top: 80px;
+	}
+
+	.header-navbar-background {
+		height: 80px;
+	}
+	.header-navbar-menu {
+		margin-top: 14px;
+		margin-left: 15px;
+		margin-right: 15px;
+		float: right;
+	}
+}

--- a/wwwroot/phpbb/styles/spring/theme/stylesheet.css
+++ b/wwwroot/phpbb/styles/spring/theme/stylesheet.css
@@ -8,4 +8,5 @@
 /* PhpBB specific Spring css */
 @import url("spring.css");
 @import url("overrides.css");
+@import url("header-navbar.css");
 @import url("normalize.css");

--- a/wwwroot/templates/header-offsite.html
+++ b/wwwroot/templates/header-offsite.html
@@ -1,0 +1,50 @@
+<div id="wrapper">
+	<div id="header">
+		<div class="header-navbar-background">
+			<div class="header-navbar-container">
+				<a href="/"><img src="https://springrts.com/images/logo.png" class="spring-logo"></a>
+				<div class="header-navbar-menu">
+					<ul>
+						<li>
+							<a href="/wiki/About">About</a>
+						</li>
+
+						<li>
+							<a href="/wiki/Games">Games</a>
+						</li>
+
+						<li>
+							<a href="/wiki/Engine_Development">Development</a>
+						</li>
+
+						<li>
+							<a href="/media.php">Media</a>
+						</li>
+
+						<li>
+							<a href="/wiki/FAQ">Help</a>
+						</li>
+
+						<li>
+							<a href="/phpbb">Forums</a>
+						</li>
+
+						<li>
+							<a href="/wiki">Wiki</a>
+						</li>
+
+						<li>
+							<a href="/mantis">Report a bug</a>
+						</li>
+
+						<li>
+							<a href="/wiki/Download">Download</a>
+						</li>
+					</ul>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<div id="maincontentwrapper">
+		<div class="locationbar">{PAGE_TITLE}</div>


### PR DESCRIPTION
This bar would only happen when you were not on the main site. Like if you were on the forums, wiki or mantis, you would get this nav bar that helps you navigate the entire site at any time.

Looks like this: http://i.imgur.com/Dj3PLyl.png

(Without the home and download icons btw)