### PR TITLE
Fix alignment of navbar menu text on wiki

### DIFF
--- a/wwwroot/header-navbar-wiki-overrides.css
+++ b/wwwroot/header-navbar-wiki-overrides.css
@@ -16,7 +16,7 @@ ul, menu, dir {
 
 /* I hate phpbb */
 .header-navbar-menu {
-	margin-top: 8px;
+	margin-top: 9px;
 }
 
 /* Now this si jsut getting pathetic -_- */

--- a/wwwroot/phpbb/styles/spring/theme/header-navbar.css
+++ b/wwwroot/phpbb/styles/spring/theme/header-navbar.css
@@ -49,7 +49,7 @@
 
 .header-navbar-menu ul li a {
 	color: #fff;
-	text-decoration: none;
+	text-decoration: none !important;
 }
 
 .header-navbar-menu ul li a:hover {


### PR DESCRIPTION
I also added important to the text decoration none just in case it wanted to try to be slick.