### PR TITLE
Fix for missing quick links bars

### DIFF
--- a/wwwroot/phpbb/styles/spring/theme/common.css
+++ b/wwwroot/phpbb/styles/spring/theme/common.css
@@ -293,8 +293,6 @@ ul.linklist li.responsive-menu a.responsive-menu-link:before {
 	top: 7px;
 	height: .125em;
 	width: 14px;
-	border-bottom: 0.125em solid transparent;
-	border-top: 0.375em double transparent;
 }
 
 .hasjs ul.linklist.leftside, .hasjs ul.linklist.rightside {


### PR DESCRIPTION
On non-hover they are missing, this fixes that:
http://imgur.com/RbAiCwQ