### PR TITLE
Enable de mediawiki API

### DIFF
--- a/wwwroot/mediawiki/LocalSettings.php
+++ b/wwwroot/mediawiki/LocalSettings.php
@@ -209,3 +209,4 @@ require_once "$IP/extensions/ParserFunctions/ParserFunctions.php";
 $wgPFEnableStringFunctions = true;
 require_once "$IP/extensions/SyntaxHighlight_GeSHi/SyntaxHighlight_GeSHi.php";
 
+$wgEnableAPI = true; # Enables the mediawiki API


### PR DESCRIPTION
This is needed by a bot i'm working on to query the wiki on commands sent from lobby